### PR TITLE
Add automated Database Migrations

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,11 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace whale_spotting
 {
@@ -14,7 +10,14 @@ namespace whale_spotting
         public static void Main(string[] args)
         {
             DotNetEnv.Env.Load();
-            CreateHostBuilder(args).Build().Run();
+            var host = CreateHostBuilder(args).Build();
+
+            using var scope = host.Services.CreateScope();
+            var serviceProvider = scope.ServiceProvider;
+            var dbContext = serviceProvider.GetService<WhaleSpottingContext>();
+            dbContext!.Database.Migrate();
+            
+            host.Run();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,10 +1,11 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
+using System;
 using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.EntityFrameworkCore;
 
 namespace whale_spotting
 {
@@ -22,6 +23,8 @@ namespace whale_spotting
         {
 
             services.AddControllersWithViews();
+            services.AddDbContext<WhaleSpottingContext>(options =>
+                options.UseNpgsql(Environment.GetEnvironmentVariable("DATABASE_URL")));
 
             // In production, the React files will be served from this directory
             services.AddSpaStaticFiles(configuration =>

--- a/WhaleSpottingContext.cs
+++ b/WhaleSpottingContext.cs
@@ -9,6 +9,9 @@ namespace whale_spotting
     {
         public DbSet<Sighting> Sightings { get; set; }
 
+        public WhaleSpottingContext(DbContextOptions<WhaleSpottingContext> options): base(options)
+        {}
+
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         { 
             optionsBuilder.UseNpgsql(Environment.GetEnvironmentVariable("DATABASE_URL"));


### PR DESCRIPTION
So... I've not actually tested this because I didn't have time to set up a database.... but its very similar to what's worked for me before! 😂 

(definitely worth testing before merging)

It _should_ just attempt to run migrations on app startup, which should mean that everyone can largely forget about them both locally and on production :)  